### PR TITLE
Silently ignore empty message sender

### DIFF
--- a/Sources/IRC/IRCClient.swift
+++ b/Sources/IRC/IRCClient.swift
@@ -583,10 +583,7 @@ extension IRCClient : IRCDispatcher {
                       recipients : [ IRCMessageRecipient ],
                       message    : String) throws
   {
-    guard let sender = sender else { // should never happen
-      assertionFailure("got empty message sender!")
-      return
-    }
+    guard let sender = sender else { return }
     delegate?.client(self, message: message, from: sender, for: recipients)
   }
 


### PR DESCRIPTION
Replaces the assertion failure with a silent return to ignore an empty message sender. This seems to be harmless. Connecting to servers like `irc.zeronode.net` will succeed instead of crashing.